### PR TITLE
Make update function compatible with new robust PooPy history functions

### DIFF
--- a/update.py
+++ b/update.py
@@ -77,16 +77,17 @@ def upload_downstream_impact_files_to_s3(
         profile_name=PROFILE_NAME,
     )
 
-
-def upload_historical_data_files_to_s3(json_file_path: str, timestamp: str) -> None:
-    """Uploads the downstream impact files to the ThamesSewage AWS bucket"""
-    # Empty the 'now' folder
+def delete_historical_data_files_from_s3() -> None:
+    """Deletes the historical data files from the ThamesSewage AWS bucket"""
     empty_s3_folder(
         bucket_name=BUCKET_NAME,
         folder_name=AWS_HISTORICAL_DIR,
         profile_name=PROFILE_NAME,
     )
-    # Upload file to current 'now' output and also the long-term storage 'past' folder
+
+
+def upload_historical_data_files_to_s3(json_file_path: str, timestamp: str) -> None:
+    """Uploads the downstream impact files to the ThamesSewage AWS bucket"""
     upload_file_to_s3(
         file_path=LOCAL_HISTORICAL_DATA_DIR + json_file_path,
         bucket_name=BUCKET_NAME,
@@ -137,6 +138,8 @@ def main():
     )
 
     print("Fetching historical discharge information")
+    # We do this first so that if the Thames Water API fails we aren't left with out of date data
+    delete_historical_data_files_from_s3()
     json_file_name = now.strftime("%y%m%d_%H%M%S.json")
     tw.set_all_histories()
     df = tw.history_to_discharge_df()


### PR DESCRIPTION
In a recent [PR for PooPy](https://github.com/AlexLipp/POOPy/commit/7697a31a34e7ff0c2ed4b2019ab88b36a6c2a79b), the functions that generate the discharge history for a monitor based on the Thames Water API was updated. The method is more robust and prevents the system breaking if an erroneous  empty response is returned. 

This PR updates the `update.py` script to better incorporate these changes and moire elegant respond if this problem is encountered. In `PooPy` if an empty response is received, an exception is raised and the script aborts. Ideally, if this is the case, there is no history at all displayed on SewageMap as the data cannot be trusted. To implement this behaviour, I now always delete the data present in the AWS bucket before generating a new history. If the exception is raised, then there is no history present in the API. If it is not raised, then the history is updated. There is however, a brief (~1 minute) downtime when the history is updating when it won't be visible.  